### PR TITLE
Envelop the script in a function that gets called document ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
 - Envelop code in document ready callback
 
 ## [0.0.2] - 2020-01-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Envelop code in document ready callback
 
 ## [0.0.2] - 2020-01-07
 ### Fix

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -1,59 +1,75 @@
-<script type='text/javascript' src='https://service.force.com/embeddedservice/5.0/esw.min.js'></script>
-<script type='text/javascript'>
-	var initESW = function(gslbBaseURL) {
-		embedded_svc.settings.displayHelpButton = true; //O falso
-		embedded_svc.settings.language = 'es';
+<script defer type='text/javascript' src='https://service.force.com/embeddedservice/5.0/esw.min.js'></script>
+<script type='text/javascript' defer>
+	var callback = function(){
+	  // Handler when the DOM is fully loaded
 
-		//embedded_svc.settings.defaultMinimizedText = '...'; //(Toma como valor predeterminado Sesión de chat con un experto)
-		//embedded_svc.settings.disabledMinimizedText = '...'; //(Toma como valor predeterminado Agente sin conexión)
+	  	var initESW = function(gslbBaseURL) {
+	  		embedded_svc.settings.displayHelpButton = true; //O falso
+	  		embedded_svc.settings.language = 'es';
 
-		//embedded_svc.settings.loadingText = ''; //(Toma como valor predeterminado Cargando)
-		//embedded_svc.settings.storageDomain = 'yourdomain.com'; //(Establece el dominio para su desarrollo de modo que los visitantes puedan navegar por subdominios durante una sesión de chat)
+	  		//embedded_svc.settings.defaultMinimizedText = '...'; //(Toma como valor predeterminado Sesión de chat con un experto)
+	  		//embedded_svc.settings.disabledMinimizedText = '...'; //(Toma como valor predeterminado Agente sin conexión)
 
-		// Configuración para Chat
-		//embedded_svc.settings.directToButtonRouting = function(prechatFormData) {
-			// Dynamically changes the button ID based on what the visitor enters in the pre-chat form.
-			// Returns a valid button ID.
-		//};
-		//embedded_svc.settings.prepopulatedPrechatFields = {}; //Establece la cumplimentación automática de los campos del formulario previo al chat
-		//embedded_svc.settings.fallbackRouting = []; //Una matriz de identificadores de botones, de usuario o userId_buttonId
-		//embedded_svc.settings.offlineSupportMinimizedText = '...'; //(Toma como valor predeterminado la opción Contacto)
+	  		//embedded_svc.settings.loadingText = ''; //(Toma como valor predeterminado Cargando)
+	  		//embedded_svc.settings.storageDomain = 'yourdomain.com'; //(Establece el dominio para su desarrollo de modo que los visitantes puedan navegar por subdominios durante una sesión de chat)
 
-    var extraPrechatFormDetails = window.decodeURIComponent('{{settings.extraPrechatFormDetails}}')
-		embedded_svc.settings.extraPrechatFormDetails = JSON.parse(extraPrechatFormDetails);
+	  		// Configuración para Chat
+	  		//embedded_svc.settings.directToButtonRouting = function(prechatFormData) {
+	  			// Dynamically changes the button ID based on what the visitor enters in the pre-chat form.
+	  			// Returns a valid button ID.
+	  		//};
+	  		//embedded_svc.settings.prepopulatedPrechatFields = {}; //Establece la cumplimentación automática de los campos del formulario previo al chat
+	  		//embedded_svc.settings.fallbackRouting = []; //Una matriz de identificadores de botones, de usuario o userId_buttonId
+	  		//embedded_svc.settings.offlineSupportMinimizedText = '...'; //(Toma como valor predeterminado la opción Contacto)
 
-    var extraPrechatInfo = window.decodeURIComponent('{{settings.extraPrechatInfo}}')
-		embedded_svc.settings.extraPrechatInfo = JSON.parse(extraPrechatInfo);
+	      var extraPrechatFormDetails = window.decodeURIComponent('{{settings.extraPrechatFormDetails}}')
+	  		embedded_svc.settings.extraPrechatFormDetails = JSON.parse(extraPrechatFormDetails);
 
-    var enabledFeatures = window.decodeURIComponent('{{settings.enabledFeatures}}')
-		embedded_svc.settings.enabledFeatures = JSON.parse(enabledFeatures);
-		embedded_svc.settings.entryFeature = '{{settings.entryFeature}}';
+	      var extraPrechatInfo = window.decodeURIComponent('{{settings.extraPrechatInfo}}')
+	  		embedded_svc.settings.extraPrechatInfo = JSON.parse(extraPrechatInfo);
 
-		embedded_svc.init(
-			window.decodeURIComponent('{{settings.urlOne}}'),
-			window.decodeURIComponent('{{settings.urlTwo}}'),
-			gslbBaseURL,
-			'00DP0000000Dhn3',
-			'{{settings.accountName}}',
-			{
-				baseLiveAgentContentURL: 'https://c.la1-c2cs-ia2.salesforceliveagent.com/content',
-				deploymentId: '{{settings.deploymentId}}',
-				buttonId: '{{settings.buttonId}}',
-				baseLiveAgentURL: 'https://d.la1-c2cs-ia2.salesforceliveagent.com/chat',
-				eswLiveAgentDevName: '{{settings.eswLiveAgentDevName}}',
-				isOfflineSupportEnabled: {{settings.isOfflineSupportEnabled}}
-			}
-		);
+	      var enabledFeatures = window.decodeURIComponent('{{settings.enabledFeatures}}')
+	  		embedded_svc.settings.enabledFeatures = JSON.parse(enabledFeatures);
+	  		embedded_svc.settings.entryFeature = '{{settings.entryFeature}}';
+
+	  		embedded_svc.init(
+	  			window.decodeURIComponent('{{settings.urlOne}}'),
+	  			window.decodeURIComponent('{{settings.urlTwo}}'),
+	  			gslbBaseURL,
+	  			'00DP0000000Dhn3',
+	  			'{{settings.accountName}}',
+	  			{
+	  				baseLiveAgentContentURL: 'https://c.la1-c2cs-ia2.salesforceliveagent.com/content',
+	  				deploymentId: '{{settings.deploymentId}}',
+	  				buttonId: '{{settings.buttonId}}',
+	  				baseLiveAgentURL: 'https://d.la1-c2cs-ia2.salesforceliveagent.com/chat',
+	  				eswLiveAgentDevName: '{{settings.eswLiveAgentDevName}}',
+	  				isOfflineSupportEnabled: {{settings.isOfflineSupportEnabled}}
+	  			}
+	  		);
+	  	};
+
+	  	if (!window.embedded_svc) {
+	  		var s = document.createElement('script');
+	  		s.setAttribute('src', '{{settings.urlone}}/embeddedservice/5.0/esw.min.js');
+	  		s.onload = function() {
+	  			initESW(null);
+	  		};
+	  		document.body.appendChild(s);
+	  	} else {
+	  		initESW('https://service.force.com');
+	  	}
+
 	};
 
-	if (!window.embedded_svc) {
-		var s = document.createElement('script');
-		s.setAttribute('src', '{{settings.urlone}}/embeddedservice/5.0/esw.min.js');
-		s.onload = function() {
-			initESW(null);
-		};
-		document.body.appendChild(s);
+	if (
+	    document.readyState === "complete" ||
+	    (document.readyState !== "loading" && !document.documentElement.doScroll)
+	) {
+	  callback();
 	} else {
-		initESW('https://service.force.com');
+	  document.addEventListener("DOMContentLoaded", callback);
 	}
+
+	
 </script>


### PR DESCRIPTION
This is a solution we found for issue #3 
Apparently the script needed to run after page content so we enveloped it in a callback that runs on document ready. And now it's loading:
![image](https://user-images.githubusercontent.com/49657838/72461752-66fe4b00-37ae-11ea-8977-cbacd8aa5dd4.png)
We're testing it in this workspace https://chat--babycottonsar.myvtex.com/

This would be a Patch release.
I don't think new documentation is required.